### PR TITLE
fix 'push' boolean flag for ecr-build

### DIFF
--- a/.github/actions/ecr-build/action.yml
+++ b/.github/actions/ecr-build/action.yml
@@ -150,7 +150,7 @@ runs:
 
     - name: Push Image
       shell: bash
-      if: ${{ inputs.push }}
+      if: ${{ inputs.push == 'true' }}
       run: |-
         export ECR_REPOSITORY_URI='${{ steps.generate-env-vars.outputs.ECR_REPOSITORY_URI }}'
 


### PR DESCRIPTION
The `push` input is being improperly handled. Consider the following usage:

```yaml
# on a branch (not 'main')
- uses: 'trialspark/github-workflows/.github/actions/ecr-build@omgitsbillryan__testing'
  with:
    aws_role_name: 'my-role'
    ecr_repository_name: 'my-repo'
    docker_tags: "foo,bar"
    push: ${{ github.ref_name == 'main' }}
```

...the image is getting pushed despite `${{ github.ref_name == 'main' }}` being false. I think the param is being passed as a string literally "false".