### PR TITLE
[HOTFIX] fixes a bad substitution error during ecr_build

### DIFF
--- a/.github/actions/ecr-build/action.yml
+++ b/.github/actions/ecr-build/action.yml
@@ -114,10 +114,10 @@ runs:
             )
         done
 
-        if [ -n "${inputs.docker_build_args}" ]; then
-            IFS=', ' read -r -a build_args <<<"${inputs.docker_build_args}"
+        if [ -n '${{ inputs.docker_build_args }}' ]; then
+            IFS=', ' read -r -a build_args <<<'${{ inputs.docker_build_args }}'
             for build_arg in "${build_args[@]}"; do
-                docker_args+=("--build-arg=${build_args}")
+                docker_args+=('--build-arg=${build_args}')
             done
         fi
 


### PR DESCRIPTION
## Description

[Just ran a build for `deployment-manager`](https://github.com/trialspark/deployment-manager/actions/runs/4147793902/jobs/7175085107) and it failed:

```
/home/runner/work/_temp/b2161e4a-9440-4ca1-bf32-85e78a9b3fa3.sh: line 25: ${inputs.docker_build_args}: bad substitution
```

## More Details

I think #4 may have [introduced a bad syntax bug](https://github.com/trialspark/github-workflows/pull/4/files#diff-841ecab77b46a4f26e76dfa5f4401d111a8f9ac84a89c137c2b020b1731e600eL116-L120). This PR just reverts that piece of code back to it's original.

### Even More Details
I initially tried to revert the commit (which would be cleaner)
```
$ git revert 2e5db2f

error: commit 2e5db2f6c8ae0452d3132b98245e62aa0e26d468 is a merge but no -m option was given.
fatal: revert failed
```
...but I didn't feel like figuring out how to revert the merge commit - also I'm a fan of the descriptions ryan added in his PR.